### PR TITLE
Add Allow-Control-Allow-Origin headers to raw dump responses

### DIFF
--- a/lib/document_handler.js
+++ b/lib/document_handler.js
@@ -36,12 +36,12 @@ DocumentHandler.prototype.handleRawGet = function(key, response, skipExpire) {
   this.store.get(key, function(ret) {
     if (ret) {
       winston.verbose('retrieved raw document', { key: key });
-      response.writeHead(200, { 'content-type': 'text/plain; charset=UTF-8' });
+      response.writeHead(200, { 'content-type': 'application/json; charset=UTF-8', 'Allow-Control-Allow-Origin': '*' });
       response.end((key === 'about' ? ret : JSON.stringify(JSON.parse(ret), null, 4)));
     }
     else {
       winston.warn('raw document not found', { key: key });
-      response.writeHead(404, { 'content-type': 'application/json' });
+      response.writeHead(404, { 'content-type': 'application/json; charset=UTF-8', 'Allow-Control-Allow-Origin': '*' });
       response.end(JSON.stringify({ message: 'Document not found.' }));
     }
   }, skipExpire);


### PR DESCRIPTION
This also makes it always return JSON, which dumps are always JSON.